### PR TITLE
Expose export key to JavaScript

### DIFF
--- a/src/client_login.rs
+++ b/src/client_login.rs
@@ -10,6 +10,7 @@ pub struct Login {
     state: Option<ClientLogin<Default>>,
     rng: OsRng,
     session_key: Option<Vec<u8>>,
+    export_key: Option<Vec<u8>>,
 }
 
 #[wasm_bindgen]
@@ -20,6 +21,7 @@ impl Login {
             rng: OsRng,
             state: None,
             session_key: None,
+            export_key: None,
         }
     }
 
@@ -53,12 +55,18 @@ impl Login {
             .unwrap();
 
         self.session_key = Some(result.session_key);
+        self.export_key = Some(result.export_key.to_vec());
 
         return Ok(result.message.serialize());
     }
 
     #[wasm_bindgen(js_name = getSessionKey)]
-    pub fn get_session_key(self) -> Result<Vec<u8>, JsValue> {
-        return Ok(self.session_key.unwrap());
+    pub fn get_session_key(&self) -> Result<Vec<u8>, JsValue> {
+        return Ok(self.session_key.to_owned().unwrap().to_vec());
+    }
+
+    #[wasm_bindgen(js_name = getExportKey)]
+    pub fn get_export_key(&self) -> Result<Vec<u8>, JsValue> {
+        return Ok(self.export_key.to_owned().unwrap());
     }
 }

--- a/src/client_registration.rs
+++ b/src/client_registration.rs
@@ -7,6 +7,7 @@ use wasm_bindgen::prelude::*;
 pub struct Registration {
     state: Option<ClientRegistration<Default>>,
     rng: OsRng,
+    export_key: Option<Vec<u8>>,
 }
 
 #[wasm_bindgen]
@@ -16,6 +17,7 @@ impl Registration {
         Registration {
             rng: OsRng,
             state: None,
+            export_key: None,
         }
     }
 
@@ -30,14 +32,16 @@ impl Registration {
         return Ok(client_registration_start_result.message.serialize());
     }
 
-    pub fn finish(self, message: Vec<u8>) -> Result<Vec<u8>, JsValue> {
+    pub fn finish(&mut self, message: Vec<u8>) -> Result<Vec<u8>, JsValue> {
         let message = match RegistrationResponse::deserialize(&message[..]) {
             Ok(message) => message,
             Err(_e) => return Err("Message deserialize failed".into()),
         };
         let mut rng = self.rng;
 
-        let client_finish_registration_result = match self.state.unwrap().finish(
+        let state = self.state.take();
+
+        let client_finish_registration_result = match state.unwrap().finish(
             &mut rng,
             message,
             ClientRegistrationFinishParameters::default(),
@@ -45,6 +49,14 @@ impl Registration {
             Ok(reply) => reply,
             Err(_e) => return Err("Mismatch messagess".into()),
         };
+
+        self.export_key = Some(client_finish_registration_result.export_key.to_vec());
+
         return Ok(client_finish_registration_result.message.serialize());
+    }
+
+    #[wasm_bindgen(js_name = getExportKey)]
+    pub fn get_export_key(&self) -> Result<Vec<u8>, JsValue> {
+        return Ok(self.export_key.to_owned().unwrap());
     }
 }


### PR DESCRIPTION
The export key is a useful secret to have available ([as in the parent library's digital locker example](https://github.com/novifinancial/opaque-ke/blob/master/examples/digital_locker.rs)); this commit allows the value to be retrieved on registration and login. 

I had to make a few changes related to data ownership to satisfy the borrow checker (and prevent the `Login` from being consumed on calls to `getSessionKey`/`getExportKey`). I'm relatively unfamiliar with writing Rust, so there may be a more proper way.

(By the way, thank you for writing these bindings; they are exactly what I needed 😄 )