### PR TITLE
bump to version 0.6 of upstream library

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,10 +15,10 @@ default = ["console_error_panic_hook"]
 
 [dependencies]
 wasm-bindgen = "0.2.63"
-opaque-ke = { version = "0.5.0", features = ["slow-hash"] }
+opaque-ke = { version = "0.6.0", features = ["slow-hash"] }
 curve25519-dalek = "3"
 sha2 = "0.9.2"
-scrypt = { version = "0.5.0" }
+argon2 = "0.2"
 rand = { version = "0.8.3" }
 getrandom = { version = "0.2", features = ["js", "wasm-bindgen"] }
 

--- a/js-test/test.mjs
+++ b/js-test/test.mjs
@@ -1,29 +1,26 @@
-import { Registration, Login, HandleRegistration, HandleLogin } from 'opaque-wasm';
+import { Registration, Login, HandleRegistration, HandleLogin, ServerSetup } from 'opaque-wasm';
 
 const password = 'test123'
 const email = 'dave@test.com'
 
-const server_setup = [147, 247, 74, 209, 29, 21, 95, 90, 97, 242, 125, 34, 136, 223, 173, 116, 63,
-  164, 126, 252, 198, 243, 135, 64, 69, 0, 64, 178, 190, 1, 40, 125, 217, 54, 67,
-  187, 66, 173, 121, 60, 150, 7, 101, 19, 74, 224, 228, 130, 168, 5, 96, 88, 127,
-  241, 191, 230, 155, 214, 122, 60, 226, 196, 172, 177, 121, 119, 153, 115, 32,
-  236, 37, 154, 207, 132, 180, 188, 199, 132, 163, 79, 70, 173, 17, 198, 252,
-  112, 86, 159, 28, 97, 140, 96, 30, 209, 42, 9, 137, 44, 124, 226, 127, 150,
-  127, 209, 152, 53, 133, 71, 143, 251, 132, 142, 3, 56, 166, 184, 7, 48, 104,
-  117, 200, 230, 107, 179, 37, 234, 144, 1]
-
-
 async function run() {
   console.log('--- STARTING ---')
 
+  // Server configuration; this must be saved.
+  let server_setup = new ServerSetup()
+
+  // Save and reload the ServerSetup for demonstration
+  const server_setup_export = server_setup.serialize();
+  server_setup = ServerSetup.deserialize(server_setup_export);
+  
   // User registration
   const registration = new Registration()
   const registration_tx = registration.start(password)
 
   console.log('--- begin ---', registration_tx)
 
-  const serverRegistration = new HandleRegistration()
-  const registration_response = serverRegistration.start(email, registration_tx, server_setup)
+  const serverRegistration = new HandleRegistration(server_setup)
+  const registration_response = serverRegistration.start(email, registration_tx)
   console.log('-- server response --', registration_response)
 
 
@@ -33,7 +30,6 @@ async function run() {
   const password_file = serverRegistration.finish(registration_final)
   console.log('-- password_file --', password_file)
 
-
   // User Login
 
   const login = new Login()
@@ -42,8 +38,9 @@ async function run() {
 
   console.log(login)
 
-  const serverLogin = new HandleLogin()
-  const login_response = serverLogin.start(password_file, email, login_tx, server_setup)
+  const serverLogin = new HandleLogin(server_setup)
+  const login_response = serverLogin.start(password_file, email, login_tx)
+
   console.log('login_response', login_response)
 
   const login_final = login.finish(login_response)

--- a/js-test/test.mjs
+++ b/js-test/test.mjs
@@ -3,7 +3,15 @@ import { Registration, Login, HandleRegistration, HandleLogin } from 'opaque-was
 const password = 'test123'
 const email = 'dave@test.com'
 
-const server_privatekey = 'c95843d9c67f7ba7f1231af10e1a88dc' // XXX: must be 32 chars long
+const server_setup = [147, 247, 74, 209, 29, 21, 95, 90, 97, 242, 125, 34, 136, 223, 173, 116, 63,
+  164, 126, 252, 198, 243, 135, 64, 69, 0, 64, 178, 190, 1, 40, 125, 217, 54, 67,
+  187, 66, 173, 121, 60, 150, 7, 101, 19, 74, 224, 228, 130, 168, 5, 96, 88, 127,
+  241, 191, 230, 155, 214, 122, 60, 226, 196, 172, 177, 121, 119, 153, 115, 32,
+  236, 37, 154, 207, 132, 180, 188, 199, 132, 163, 79, 70, 173, 17, 198, 252,
+  112, 86, 159, 28, 97, 140, 96, 30, 209, 42, 9, 137, 44, 124, 226, 127, 150,
+  127, 209, 152, 53, 133, 71, 143, 251, 132, 142, 3, 56, 166, 184, 7, 48, 104,
+  117, 200, 230, 107, 179, 37, 234, 144, 1]
+
 
 async function run() {
   console.log('--- STARTING ---')
@@ -15,7 +23,7 @@ async function run() {
   console.log('--- begin ---', registration_tx)
 
   const serverRegistration = new HandleRegistration()
-  const registration_response = serverRegistration.start(registration_tx, server_privatekey)
+  const registration_response = serverRegistration.start(email, registration_tx, server_setup)
   console.log('-- server response --', registration_response)
 
 
@@ -35,7 +43,7 @@ async function run() {
   console.log(login)
 
   const serverLogin = new HandleLogin()
-  const login_response = serverLogin.start(password_file, login_tx, server_privatekey)
+  const login_response = serverLogin.start(password_file, email, login_tx, server_setup)
   console.log('login_response', login_response)
 
   const login_final = login.finish(login_response)

--- a/src/client_login.rs
+++ b/src/client_login.rs
@@ -1,6 +1,6 @@
 use crate::hash_methods::Default;
 use opaque_ke::{
-    ClientLogin, ClientLoginFinishParameters, ClientLoginStartParameters, CredentialResponse,
+    ClientLogin, ClientLoginFinishParameters, CredentialResponse,
 };
 use rand::rngs::OsRng;
 use wasm_bindgen::prelude::*;
@@ -28,8 +28,7 @@ impl Login {
     pub fn start(&mut self, password: &str) -> Result<Vec<u8>, JsValue> {
         let client_login_start_result = match ClientLogin::<Default>::start(
             &mut self.rng,
-            &password.as_bytes(),
-            ClientLoginStartParameters::default(),
+            &password.as_bytes()
         ) {
             Ok(client_login_start_result) => client_login_start_result,
             Err(_e) => return Err("Failed start".into()),

--- a/src/handle_login.rs
+++ b/src/handle_login.rs
@@ -27,17 +27,22 @@ impl HandleLogin {
 
     pub fn start(
         &mut self,
-        password_file: Vec<u8>,
+        password_file: Option<Vec<u8>>,
         identifier: Vec<u8>,
         credential_request: Vec<u8>,
     ) -> Result<Vec<u8>, JsValue> {
+
         let request = CredentialRequest::deserialize(&credential_request[..]).unwrap();
-        let password = ServerRegistration::<Default>::deserialize(&password_file[..]).unwrap();
+
+        let password = match password_file {
+            Some(val) => Some(ServerRegistration::<Default>::deserialize(&val).unwrap()),
+            None => None
+        };
 
         let server_login_start_result = match ServerLogin::start(
             &mut self.rng,
             self.setup.internal(),
-            Some(password),
+            password,
             request,
             &identifier,
             ServerLoginStartParameters::default(),

--- a/src/handle_registration.rs
+++ b/src/handle_registration.rs
@@ -1,12 +1,9 @@
 use crate::hash_methods::Default;
-use opaque_ke::{keypair::KeyPair, RegistrationRequest, RegistrationUpload, ServerRegistration};
-use rand::rngs::OsRng;
+use opaque_ke::{RegistrationRequest, RegistrationUpload, ServerRegistration, ServerSetup};
 use wasm_bindgen::prelude::*;
 
 #[wasm_bindgen]
 pub struct HandleRegistration {
-    rng: OsRng,
-    state: Option<ServerRegistration<Default>>,
 }
 
 #[wasm_bindgen]
@@ -14,40 +11,34 @@ impl HandleRegistration {
     #[wasm_bindgen(constructor)]
     pub fn new() -> HandleRegistration {
         HandleRegistration {
-            rng: OsRng,
-            state: None,
         }
     }
 
     pub fn start(
         &mut self,
+        identifier: Vec<u8>,
         registration_request: Vec<u8>,
-        server_privatekey: Vec<u8>,
+        server_setup: Vec<u8>,
     ) -> Result<Vec<u8>, JsValue> {
-        let server_kp =
-            KeyPair::<curve25519_dalek::ristretto::RistrettoPoint>::from_private_key_slice(
-                &server_privatekey,
-            )
-            .unwrap();
+        let server_setup = ServerSetup::deserialize(&server_setup).unwrap();
         let request = match RegistrationRequest::deserialize(&registration_request[..]) {
             Ok(message) => message,
             Err(_e) => return Err("Message deserialize failed".into()),
         };
 
         let server_registration_start_result =
-            match ServerRegistration::<Default>::start(&mut self.rng, request, &server_kp.public())
+            match ServerRegistration::<Default>::start(&server_setup, request, &identifier)
             {
                 Ok(message) => message,
                 Err(_e) => return Err("Message deserialize failed".into()),
             };
 
-        self.state = Some(server_registration_start_result.state);
         return Ok(server_registration_start_result.message.serialize());
     }
 
     pub fn finish(self, registration_finish: Vec<u8>) -> Result<Vec<u8>, JsValue> {
         let message = RegistrationUpload::deserialize(&registration_finish[..]).unwrap();
-        let password_file = self.state.unwrap().finish(message).unwrap();
+        let password_file = ServerRegistration::<Default>::finish(message);
 
         return Ok(password_file.serialize());
     }

--- a/src/handle_registration.rs
+++ b/src/handle_registration.rs
@@ -1,33 +1,34 @@
 use crate::hash_methods::Default;
-use opaque_ke::{RegistrationRequest, RegistrationUpload, ServerRegistration, ServerSetup};
+use crate::server_setup::ServerSetup;
+use opaque_ke::{RegistrationRequest, RegistrationUpload, ServerRegistration};
 use wasm_bindgen::prelude::*;
 
 #[wasm_bindgen]
 pub struct HandleRegistration {
+    setup: ServerSetup
 }
 
 #[wasm_bindgen]
 impl HandleRegistration {
     #[wasm_bindgen(constructor)]
-    pub fn new() -> HandleRegistration {
+    pub fn new(setup: &ServerSetup) -> HandleRegistration {
         HandleRegistration {
+            setup: setup.clone()
         }
     }
 
     pub fn start(
-        &mut self,
+        &self,
         identifier: Vec<u8>,
         registration_request: Vec<u8>,
-        server_setup: Vec<u8>,
     ) -> Result<Vec<u8>, JsValue> {
-        let server_setup = ServerSetup::deserialize(&server_setup).unwrap();
         let request = match RegistrationRequest::deserialize(&registration_request[..]) {
             Ok(message) => message,
             Err(_e) => return Err("Message deserialize failed".into()),
         };
 
         let server_registration_start_result =
-            match ServerRegistration::<Default>::start(&server_setup, request, &identifier)
+            match ServerRegistration::<Default>::start(self.setup.internal(), request, &identifier)
             {
                 Ok(message) => message,
                 Err(_e) => return Err("Message deserialize failed".into()),

--- a/src/hash_methods.rs
+++ b/src/hash_methods.rs
@@ -5,5 +5,5 @@ impl CipherSuite for Default {
     type Group = curve25519_dalek::ristretto::RistrettoPoint;
     type KeyExchange = opaque_ke::key_exchange::tripledh::TripleDH;
     type Hash = sha2::Sha512;
-    type SlowHash = scrypt::ScryptParams;
+    type SlowHash = argon2::Argon2<'static>;
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,7 @@ pub mod client_login;
 pub mod client_registration;
 pub mod handle_login;
 pub mod handle_registration;
+pub mod server_setup;
 mod hash_methods;
 mod utils;
 
@@ -15,3 +16,4 @@ pub use client_login::Login;
 pub use client_registration::Registration;
 pub use handle_login::HandleLogin;
 pub use handle_registration::HandleRegistration;
+pub use server_setup::ServerSetup;

--- a/src/server_setup.rs
+++ b/src/server_setup.rs
@@ -1,0 +1,41 @@
+use crate::hash_methods::Default;
+use wasm_bindgen::prelude::*;
+use rand::rngs::OsRng;
+
+#[wasm_bindgen]
+#[derive(Clone)]
+pub struct ServerSetup {
+    internal: opaque_ke::ServerSetup<Default>
+}
+
+#[wasm_bindgen]
+impl ServerSetup {
+
+    #[wasm_bindgen(constructor)]
+    pub fn new() -> ServerSetup {
+        let mut rng = OsRng;
+        let internal = opaque_ke::ServerSetup::new(&mut rng);
+
+        ServerSetup { internal }
+    }
+
+    pub fn serialize(&self) -> Vec<u8> {
+        self.internal.serialize()
+    }
+
+    pub fn deserialize(input: Vec<u8>) -> Result<ServerSetup, JsValue> {
+        let internal  = match opaque_ke::ServerSetup::deserialize(&input) {
+            Ok(val) => val,
+            Err(_) => return Err("Failed to load serialized ServerSetup".into())
+        };
+        Ok(
+            ServerSetup {
+                internal
+            }
+        )
+    }
+
+    pub(crate) fn internal<'a>(&'a self) -> &'a opaque_ke::ServerSetup<Default> {
+        &self.internal
+    }
+}


### PR DESCRIPTION
This bumps up the version of the upstream `opaque-ke` library to the newly released 0.6 version.

For the purposes of this library, the big (user-facing, and breaking)  changes are:

- replacing Scrypt with Argon2
- replacing a user-provided server public/private keypair with a generated `ServerSetup` object
  - note: maybe an interface to generate these should be added?
- taking in a registration identifier to the server register/login functions