### PR TITLE
Allow building separate client/server packages

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,9 @@ description = "An implementation of the OPAQUE key exchange protocol in WASM(Web
 crate-type = ["cdylib", "rlib"]
 
 [features]
-default = ["console_error_panic_hook"]
+default = ["console_error_panic_hook", "client", "server"]
+client = ["console_error_panic_hook", "wee_alloc"]
+server = ["console_error_panic_hook"]
 
 [dependencies]
 wasm-bindgen = "0.2.63"
@@ -43,6 +45,7 @@ wasm-bindgen-test = "0.3.13"
 [profile.release]
 # Tell `rustc` to optimize for small code size.
 opt-level = "s"
+strip = "debuginfo"
 
 [package.metadata.wasm-pack.profile.release]
 wasm-opt = false

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,8 +1,14 @@
+#[cfg(feature = "client")]
 pub mod client_login;
+#[cfg(feature = "client")]
 pub mod client_registration;
+#[cfg(feature = "server")]
 pub mod handle_login;
+#[cfg(feature = "server")]
 pub mod handle_registration;
+#[cfg(feature = "server")]
 pub mod server_setup;
+
 mod hash_methods;
 mod utils;
 
@@ -12,8 +18,13 @@ mod utils;
 #[global_allocator]
 static ALLOC: wee_alloc::WeeAlloc = wee_alloc::WeeAlloc::INIT;
 
+#[cfg(feature = "client")]
 pub use client_login::Login;
+#[cfg(feature = "client")]
 pub use client_registration::Registration;
+#[cfg(feature = "server")]
 pub use handle_login::HandleLogin;
+#[cfg(feature = "server")]
 pub use handle_registration::HandleRegistration;
+#[cfg(feature = "server")]
 pub use server_setup::ServerSetup;


### PR DESCRIPTION
It saves a few KB on the client bundle when:
- not including the server handling code
- stripping debug symbols in release mode
- using wee_alloc

It allows shipping different targets (CJS for Node.js servers vs ESM for browser-based clients) in wasm-pack:
```
wasm-pack build --target nodejs --release --no-default-features --features server
wasm-pack build --target web --release --no-default-features --features client
```